### PR TITLE
update dockerfile to ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 MAINTAINER Jerry Cai
 


### PR DESCRIPTION
Current docker file makes use of Ubuntu 14.04 which is end of life 30th April 2019.